### PR TITLE
feat(retrievalprovider): prioritize announce addresses over host addresses

### DIFF
--- a/retrievalprovider/transports.go
+++ b/retrievalprovider/transports.go
@@ -25,7 +25,7 @@ func NewTransportsListener(h host.Host, cfg *config.MarketConfig) (*TransportsLi
 	var maddrs []multiaddr.Multiaddr
 	switch {
 	case len(cfg.Libp2p.AnnounceAddresses) > 0:
-		for i, _ := range cfg.Libp2p.AnnounceAddresses {
+		for i := range cfg.Libp2p.AnnounceAddresses {
 			maddr, err := multiaddr.NewMultiaddr(cfg.Libp2p.AnnounceAddresses[i])
 			if err == nil {
 				maddrs = append(maddrs, maddr)

--- a/retrievalprovider/transports.go
+++ b/retrievalprovider/transports.go
@@ -22,12 +22,22 @@ func NewTransportsListener(h host.Host, cfg *config.MarketConfig) (*TransportsLi
 	var protos []types.Protocol
 
 	// Get the libp2p addresses from the Host
-	if len(h.Addrs()) > 0 {
-		protos = append(protos, types.Protocol{
-			Name:      "libp2p",
-			Addresses: h.Addrs(),
-		})
+	var maddrs []multiaddr.Multiaddr
+	switch {
+	case len(cfg.Libp2p.AnnounceAddresses) > 0:
+		for i, _ := range cfg.Libp2p.AnnounceAddresses {
+			maddr, err := multiaddr.NewMultiaddr(cfg.Libp2p.AnnounceAddresses[i])
+			if err == nil {
+				maddrs = append(maddrs, maddr)
+			}
+		}
+	case len(h.Addrs()) > 0:
+		maddrs = h.Addrs()
 	}
+	protos = append(protos, types.Protocol{
+		Name:      "libp2p",
+		Addresses: maddrs,
+	})
 
 	// If there's an http retrieval address specified, add HTTP to the list
 	// of supported protocols


### PR DESCRIPTION


If announce addresses are configured, the retrieval provider now prioritizes these over the addresses directly obtained from the host. This allows fora more controlled announcement of addresses in libp2p networks.

## 关联的Issues (Related Issues)
<!-- 列出本 PR 尝试解决或修复的 issues，或者描述本 PR 的目的。 -->
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

close

## 改动 (Proposed Changes)
<!-- 改动清单 -->
<!-- provide a clear list of the changes being made-->


## 附注 (Additional Info)
<!-- 需要额外了解的信息 -->
<!-- callouts, links to documentation, and etc-->

## 自查清单 (Checklist)

在你认为本 PR 满足被审阅的标准之前，需要确保 / Before you mark the PR ready for review, please make sure that:
- [x] 符合Venus项目管理规范中关于PR的[相关标准](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E9%A1%B9%E7%9B%AE%E7%AE%A1%E7%90%86/Venus/PR%E5%91%BD%E5%90%8D%E8%A7%84%E8%8C%83.md) / The PR follows the PR standards set out in the Venus project management guidelines
- [x] 具有清晰明确的[commit message](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/git%E4%BD%BF%E7%94%A8/commit-message%E9%A3%8E%E6%A0%BC%E8%A7%84%E8%8C%83.md) / All commits have a clear commit message.
- [ ] 包含相关的的[测试用例](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/%E4%BB%A3%E7%A0%81%E5%BA%93/%E6%A3%80%E6%9F%A5%E9%A1%B9/%E5%8D%95%E5%85%83%E6%B5%8B%E8%AF%95.md)或者不需要新增测试用例 / This PR has tests for new functionality or change in behaviour or not need to add new tests.
- [ ] 包含相关的的指南以及[文档](https://github.com/ipfs-force-community/dev-guidances/tree/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E6%96%87%E6%A1%A3)或者不需要新增文档 / This PR has updated usage guidelines and documentation or not need 
- [ ] 通过必要的检查项 / All checks are green
